### PR TITLE
Fix mui grid slugs and links

### DIFF
--- a/copy/tools/material-ui-data-grid.yml
+++ b/copy/tools/material-ui-data-grid.yml
@@ -5,9 +5,14 @@ developer: Material UI
 based_on: null
 licenses:
   - type: proprietary
+    title: MUI X Premium
+    link: https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid-premium/LICENSE
+  - type: proprietary
+    title: MUI X Pro
+    link: https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid-pro/LICENSE
   - type: open-source
     title: MIT
-    link: 'https://github.com/mui-org/material-ui/blob/next/LICENSE'
+    link: 'https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/LICENSE'
 types:
   - grid
 renders:
@@ -30,18 +35,18 @@ languages:
 frameworks:
   - react
 slugs:
-  github: mui-org/material-ui
-  npm: '@material-ui/core'
+  github: mui/mui-x
+  npm: '@mui/x-data-grid'
 tags:
   stackoverflow:
     - material-ui
   twitter:
     - MaterialUI
 links:
-  website: 'https://material-ui.com/components/data-grid/'
-  examples: 'https://material-ui.com/components/tables/#data-table'
-  docs: 'https://material-ui.com/api/data-grid/data-grid/'
-  pricing: 'https://next.material-ui.com/branding/pricing/'
+  website: 'https://mui.com/x/react-data-grid/'
+  examples: 'https://mui.com/material-ui/react-table/#data-table'
+  docs: 'https://mui.com/x/api/data-grid/data-grid/'
+  pricing: 'https://mui.com/pricing/'
   slack: null
 content:
   - type: cube


### PR DESCRIPTION
Couple changes to fix data update workflow and proper links to MUI Grid

- https://github.com/mui-org was moved to https://github.com/mui (this caused pipeline failures):
<img width="959" alt="CleanShot 2022-08-01 at 12 30 17@2x" src="https://user-images.githubusercontent.com/827338/182118678-57cc3a9d-f528-4d27-b2f1-71db9fd5a02e.png">

- `DataGrid` was moved to separate mui-x repository and npm package https://github.com/mui/mui-x

- Also updated licenses details https://mui.com/pricing/
