### PR TITLE
fix: use proper links and github slug for react-charts

### DIFF
--- a/copy/tools/react-charts.yml
+++ b/copy/tools/react-charts.yml
@@ -7,7 +7,7 @@ based_on:
 licenses:
   - type: open-source
     title: MIT
-    link: 'https://github.com/tannerlinsley/react-charts/blob/main/LICENSE'
+    link: 'https://github.com/TanStack/react-charts/blob/main/LICENSE'
 types:
   - charts
 renders:
@@ -25,7 +25,7 @@ languages:
 frameworks:
   - react
 slugs:
-  github: tannerlinsley/react-charts
+  github: TanStack/react-charts
   npm: react-charts
 tags:
   stackoverflow:
@@ -49,6 +49,6 @@ github_data:
   stale_issues: 0
   last_release:
     date: '2021-11-21T04:45:18Z'
-    link: 'https://github.com/tannerlinsley/react-charts/releases/tag/v3.0.0-beta.34'
+    link: 'https://github.com/TanStack/react-charts/releases/tag/v3.0.0-beta.34'
 stackoverflow_data:
   questions_count: 10


### PR DESCRIPTION
data update pipeline started failing on `react-charts` because it was moved from personal account https://github.com/tannerlinsley/ to org https://github.com/TanStack/react-charts

https://github.com/cube-js/awesome-tools/runs/7689695118?check_suite_focus=true
<img width="953" alt="CleanShot 2022-08-05 at 14 17 40@2x" src="https://user-images.githubusercontent.com/827338/183067089-d8f30c02-2031-4ab1-9d34-5bd32d6923f1.png">

