### PR TITLE
ci: notify slack channel if there are some data update failures

### DIFF
--- a/data-update-worker/index.js
+++ b/data-update-worker/index.js
@@ -1,11 +1,14 @@
 const yaml = require("node-yaml");
 const fs = require("fs");
 const get = require("./fetchData.js");
+const { notifySlackUpdateFailures } = require("./notifySlack.js");
 
 const files = fs.readdirSync("../copy/tools");
 const ids = files
   .filter((filename) => filename.endsWith(".yml"))
   .map((filename) => filename.split(".")[0]);
+
+let failures = [];
 
 asyncForEach(ids, async (id) => {
   try {
@@ -23,6 +26,14 @@ asyncForEach(ids, async (id) => {
     await new Promise((resolve) => setTimeout(resolve, 15000));
   } catch (e) {
     console.log(`${id}`, e);
+    failures.push({
+      id,
+      error: e,
+    });
+  }
+}).then(() => {
+  if (failures.length) {
+    return notifySlackUpdateFailures(failures);
   }
 });
 

--- a/data-update-worker/notifySlack.js
+++ b/data-update-worker/notifySlack.js
@@ -1,0 +1,49 @@
+const fetch = require("node-fetch");
+require("dotenv").config();
+
+/**
+ * @param {Array<any>} blocks 
+ * @returns Promise
+ */
+const notifySlack = async (blocks) =>
+  fetch(process.env.SLACK_WEBHOOK_URL, {
+    method: "POST",
+    body: JSON.stringify({
+      blocks,
+    }),
+  });
+
+/**
+ * @param {Array<{ id: string; error: string }>} failures 
+ * @returns Promise
+ */
+const notifySlackUpdateFailures = async (failures) =>
+  notifySlack([
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "⚠️ Failed to update some tools",
+        emoji: true,
+      },
+    },
+
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `<${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}|GitHub Run>`,
+      },
+    },
+
+    ...failures.map((failure) => ({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${failure.id}:*\n${failure.error}`,
+      },
+    })),
+  ]);
+
+exports.notifySlack = notifySlack;
+exports.notifySlackUpdateFailures = notifySlackUpdateFailures;


### PR DESCRIPTION
notify slack when data updater has some failures

TODO:
- [x] set up `SLACK_WEBHOOK_URL` gh actions secret