### PR TITLE
Fix MUI X Data Grid inconsistencies

### DIFF
--- a/copy/tools/material-ui-data-grid.yml
+++ b/copy/tools/material-ui-data-grid.yml
@@ -1,7 +1,7 @@
 title: MUI X Data Grid
 description: Fast and extendable data table and data grid for React
 logo: material-ui.svg
-developer: Material UI
+developer: MUI
 based_on: null
 licenses:
   - type: proprietary
@@ -41,13 +41,13 @@ slugs:
   npm: '@mui/x-data-grid'
 tags:
   stackoverflow:
-    - material-ui
+    - mui-x
   twitter:
-    - MaterialUI
+    - MUI_hq
 links:
   website: 'https://mui.com/x/react-data-grid/'
-  examples: 'https://mui.com/material-ui/react-table/#data-table'
-  docs: 'https://mui.com/x/api/data-grid/data-grid/'
+  examples: 'https://mui.com/x/react-data-grid/#mit-version-free-forever'
+  docs: 'https://mui.com/x/react-data-grid/'
   pricing: 'https://mui.com/pricing/'
   slack: null
 content:


### PR DESCRIPTION
https://awesome.cube.dev/tools/material-ui-data-grid

This PR fixes a few inconsistencies, the main one is that MUI X is not about Material UI, and this page might make it feel like it's the case.

For example, MUI X, now also includes charts: https://mui.com/x/react-charts/ (built on top of d3, aiming to continue the work that recharts started), growth is going ok https://npm-stat.com/charts.html?package=%40mui%2Fx-charts&from=2023-01-26&to=2024-02-26.